### PR TITLE
add get_changeset function

### DIFF
--- a/docs/OTHERS.md
+++ b/docs/OTHERS.md
@@ -8,6 +8,9 @@
 # Get changesets from 1000 to 1002
 changesets = client.get_changesets(from_=1000, to_=1002)
 
+# Get just a particular changeset
+changeset = client.get_changeset(1000)
+
 # Get changesets and related Workitems
 changesets = client.get_changesets(top=1)
 linked_workitems = changesets[0].workitems

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -36,6 +36,12 @@ class TestTFSAPI:
         assert changesets[0].id == 10
 
     @pytest.mark.httpretty
+    def test_get_changeset(self, tfsapi):
+        changeset = tfsapi.get_changeset(10)
+
+        assert changeset.id == 10
+
+    @pytest.mark.httpretty
     def test_get_wiql(self, tfsapi):
         wiql_query = "SELECT *"
         wiql = tfsapi.run_wiql(wiql_query)

--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
 from urllib.parse import quote
 
 import requests
@@ -82,12 +81,15 @@ class TFSAPI:
             workitems += work_items_batch_info
         return workitems
 
+    def get_changeset(self, id_):
+        if isinstance(id_, int):
+            return self.get_changesets(from_=id_, to_=id_)[0]
+
     def get_changesets(self, from_=None, to_=None, item_path=None, top=10000):
         payload = {'$top': top}
 
         if from_ and to_:
-            match = re.search('[a-zA-Z]', from_) and re.search('[a-zA-Z]', to_)
-            if match is not None:
+            if isinstance(from_, int) and isinstance(to_, int):
                 payload['searchCriteria.fromId'] = from_
                 payload['searchCriteria.toId'] = to_
             else:


### PR DESCRIPTION
Allow querying for information for just a specific
changeset by adding the get_changeset() function.

Behind the scenes this uses the get_changesets()
function with a limit set to the from_ and to_
parameters as the argument passed to
get_changeset().

Fixes #26 