### PR TITLE
Added extra params for update_workitem and add_relations_raw

### DIFF
--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -101,10 +101,11 @@ class TFSAPI:
     def get_project(self, name):
         return self.get_tfs_object('projects/{}'.format(name), object_class=Projects)
 
-    def update_workitem(self, work_item_id, update_data):
+    def update_workitem(self, work_item_id, update_data, params=None):
         raw = self.rest_client.send_patch('wit/workitems/{id}?api-version=1.0'.format(id=work_item_id),
                                           data=update_data,
-                                          headers={'Content-Type': 'application/json-patch+json'})
+                                          headers={'Content-Type': 'application/json-patch+json'},
+                                          payload=params)
         return raw
 
     def run_query(self, path):
@@ -215,6 +216,9 @@ class TFSAPI:
         fields = workitem.data.get('fields')
         type_ = target_type if target_type else fields['System.WorkItemType']
 
+        params = {'api-version': api_version, 'validateOnly': validate_only, 'bypassRules': bypass_rules,
+                  'suppressNotifications': suppress_notifications}
+
         # When copy from another project, adjust AreaPath and IterationPath and do not copy identifying fields
         if from_another_project:
             no_copy_fields = ['System.TeamProject',
@@ -260,7 +264,7 @@ class TFSAPI:
                                   api_version)
 
         if with_links_and_attachments:
-            wi.add_relations_raw(workitem.data.get('relations', {}))
+            wi.add_relations_raw(workitem.data.get('relations', {}), params)
         return wi
 
 

--- a/tfs/resources.py
+++ b/tfs/resources.py
@@ -188,7 +188,7 @@ class Workitem(TFSObject):
         attachments_ = [Attachment(x, self.tfs) for x in list_]
         return attachments_
 
-    def add_relations_raw(self, relations_raw):
+    def add_relations_raw(self, relations_raw, params=None):
         """
         Add attachments, related (work item) links and/or hyperlinks
         :param relations_raw: List of relations. Each relation is a dict with the following keys: rel, url, attributes
@@ -203,7 +203,7 @@ class Workitem(TFSObject):
         path = '/relations/-'
         update_data = [dict(op="add", path=path, value=relation) for relation in copy_raw]
         if update_data:
-            raw = self.tfs.update_workitem(self.id, update_data)
+            raw = self.tfs.update_workitem(self.id, update_data, params)
             self.__init__(raw, self.tfs)
 
 


### PR DESCRIPTION
Being able to use [URI-parameters](https://docs.microsoft.com/en-us/rest/api/vsts/wit/work%20items/create?view=vsts-rest-4.1#uri-parameters) is a good enhancement.

It allows bypassing rules, suppressing notifications and any furhter features that would be added by Microsoft as URI-parameters.