### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Microsoft TFS Python Library (TFS API Python client)
     - [Run Saved Queries](#run-saved-queries)
     - [Run WIQL](#run-wiql)
     - [Advanced](#advanced)
+- [Troubleshooting](#troubleshooting)
 - [Guide](#guide)
     - [Compatibility](#Compatibility)
     - [Contribute](#contribute)
@@ -210,6 +211,16 @@ print(workitems[0]['Title'])
 ## Advanced
 - [Advanced usage](docs/ADVANCED.md)
 - Some [other objects available](docs/OTHERS.md)
+
+# Troubleshooting
+
+If you cannot create or update a work item, here are some possible reasons:
+- check if the account you use has **enough permissions** in the collection/project;
+- make sure you **follow your workflow**, work items might have required fields or any other sort of restrictions;
+- verify that the api version [fits your team foundation server version](https://docs.microsoft.com/en-us/vsts/integrate/concepts/rest-api-versioning);
+
+If neither of these helped your case, [look through our issues list](https://github.com/devopshq/tfs/issues).
+If there is no similar issue, [create one](https://github.com/devopshq/tfs/issues/new).
 
 # Guide
 If you use this library, [put a star](https://help.github.com/articles/about-stars/) on [this repository](https://github.com/devopshq/tfs). This motivates us and other developers to develop the library :)

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -81,6 +81,6 @@ print(links)
 ```
 
 ## TFSHTTPClient
-**TODO**: Describe how other people can use some usefull function and object from `tfs.connection`
+**TODO**: Describe how other people can use some useful function and object from `tfs.connection`
 - Get from TFSAPI
 - `send_*` methods

--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -107,10 +107,11 @@ class TFSAPI:
     def get_project(self, name):
         return self.get_tfs_object('projects/{}'.format(name), object_class=Projects)
 
-    def update_workitem(self, work_item_id, update_data):
+    def update_workitem(self, work_item_id, update_data, params=None):
         raw = self.rest_client.send_patch('wit/workitems/{id}?api-version=1.0'.format(id=work_item_id),
                                           data=update_data,
-                                          headers={'Content-Type': 'application/json-patch+json'})
+                                          headers={'Content-Type': 'application/json-patch+json'},
+                                          payload=params)
         return raw
 
     def run_query(self, path):
@@ -221,6 +222,9 @@ class TFSAPI:
         fields = workitem.data.get('fields')
         type_ = target_type if target_type else fields['System.WorkItemType']
 
+        params = {'api-version': api_version, 'validateOnly': validate_only, 'bypassRules': bypass_rules,
+                  'suppressNotifications': suppress_notifications}
+
         # When copy from another project, adjust AreaPath and IterationPath and do not copy identifying fields
         if from_another_project:
             no_copy_fields = ['System.TeamProject',
@@ -266,7 +270,7 @@ class TFSAPI:
                                   api_version)
 
         if with_links_and_attachments:
-            wi.add_relations_raw(workitem.data.get('relations', {}))
+            wi.add_relations_raw(workitem.data.get('relations', {}), params)
         return wi
 
 

--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -82,8 +82,7 @@ class TFSAPI:
         return workitems
 
     def get_changeset(self, id_):
-        if isinstance(id_, int):
-            return self.get_changesets(from_=id_, to_=id_)[0]
+        return self.get_changesets(from_=id_, to_=id_)[0]
 
     def get_changesets(self, from_=None, to_=None, item_path=None, top=10000):
         payload = {'$top': top}

--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -144,7 +144,7 @@ class TFSAPI:
 
     def __create_workitem(self, type_, data=None, validate_only=None, bypass_rules=None,
                           suppress_notifications=None,
-                          api_version=4.1):
+                          api_version=1.0):
         """
         Create work item. Param description: https://docs.microsoft.com/en-us/rest/api/vsts/wit/work%20items/create
         :param project: Name of the target project. The same project is used by default.
@@ -160,7 +160,7 @@ class TFSAPI:
 
     def create_workitem(self, type_, fields=None, relations_raw=None, validate_only=None, bypass_rules=None,
                         suppress_notifications=None,
-                        api_version=4.1):
+                        api_version=1.0):
         """
         Create work item. Doc: https://docs.microsoft.com/en-us/rest/api/vsts/wit/work%20items/create
         :param type_: Work item
@@ -202,7 +202,7 @@ class TFSAPI:
                       validate_only=None,
                       bypass_rules=None,
                       suppress_notifications=None,
-                      api_version=4.1):
+                      api_version=1.0):
         """
         Create a copy of a work item
         :param workitem: Source workitem

--- a/tfs/resources.py
+++ b/tfs/resources.py
@@ -188,7 +188,7 @@ class Workitem(TFSObject):
         attachments_ = [Attachment(x, self.tfs) for x in list_]
         return attachments_
 
-    def add_relations_raw(self, relations_raw):
+    def add_relations_raw(self, relations_raw, params=None):
         """
         Add attachments, related (work item) links and/or hyperlinks
         :param relations_raw: List of relations. Each relation is a dict with the following keys: rel, url, attributes
@@ -203,7 +203,7 @@ class Workitem(TFSObject):
         path = '/relations/-'
         update_data = [dict(op="add", path=path, value=relation) for relation in copy_raw]
         if update_data:
-            raw = self.tfs.update_workitem(self.id, update_data)
+            raw = self.tfs.update_workitem(self.id, update_data, params)
             self.__init__(raw, self.tfs)
 
 


### PR DESCRIPTION
Updated default API from version 4.1 (latest) to 1.0 (earliest).
Makes more sense:
- works on more TFS versions by default;
- better paradigm: if you want **more perks**, you **increase** API version (instead of: if you want it to **work at all**, **decrease** the API version).

Updated docs: even basic **Troubleshooting** section is pretty important, having it might save a lot of time for both users and developers.