### PR TITLE
Fail Travis build if tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ branches:
 install:
   - pip install -r requirements-travis.txt
 script:
+  - set -e
   - printenv
   - flake8 tfs
   - coverage run -m py.test tests
   - coverage xml
   - if [[ ! $CODACY_PROJECT_TOKEN ]]; then echo "Variable CODACY_PROJECT_TOKEN not set. Step is skipped."; exit 0; else python-codacy-coverage -r coverage.xml; fi
+  - set +e
 
 deploy:
 - provider: pypi


### PR DESCRIPTION
The Travis build is not marked as failure if the tests fail. This PR aims to fix this problem, but at first I'm going to intentionally try and fail the tests in order to check when the Travis build is behaving accordingly.