### PR TITLE
Add  __contains__ for workitem

### DIFF
--- a/tfs/resources.py
+++ b/tfs/resources.py
@@ -257,6 +257,14 @@ class Workitem(UnknownTfsObject):
         else:
             return key
 
+    def __contains__(self, key):
+        try:
+            self[key]
+        except KeyError:
+            return False
+        else:
+            return True
+
     @property
     def field_names(self):
         return [self._remove_prefix(x) for x in self.fields]


### PR DESCRIPTION
Fix error in case of 
if "FieldName" in workitem

Now it will return AttributeError: 'int' object has no attribute 'lower'
See https://docs.python.org/3/reference/expressions.html#membership-test-details