### PR TITLE
Error in Workitem.add_relations_raw(...) caused by wrong parameter order.

### DIFF
--- a/tfs/resources.py
+++ b/tfs/resources.py
@@ -343,7 +343,7 @@ class Workitem(UnknownTfsObject):
         update_data = [dict(op="add", path=path, value=relation) for relation in copy_raw]
         if update_data:
             raw = self.tfs.update_workitem(self.id, update_data, params)
-            self.__init__(raw, self.tfs)
+            self.__init__(raw=raw, tfs=self.tfs)
 
 
 class Attachment(UnknownTfsObject):


### PR DESCRIPTION
Parameters were switched when calling `Workitem.__init__(...)` from `Workitem.add_relations_raw(...)` causing an error.
The solution is to either switch the order of the parameters or (as proposed in this pull request) use keyword arguments.