### PR TITLE
Avoid UnboundLocalError when using TFSAPI.definitions() with default argument

### DIFF
--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -186,7 +186,7 @@ class TFSAPI:
     def definitions(self, nameFilter=None):
         """ List of build definitions
 
-        :param name: Filters to definitions whose names equal this value.
+        :param nameFilter: Filters to definitions whose names equal this value.
                      Use ``*`` as a wildcard, ex: 'Release_11.*' or 'Release_*_11.0'
         :return: list of :class:`Definition` object
          """

--- a/tfs/connection.py
+++ b/tfs/connection.py
@@ -192,6 +192,8 @@ class TFSAPI:
          """
         if nameFilter:
             payload = {'name': nameFilter}
+        else:
+            payload = None
         return self.get_tfs_resource('build/definitions', underProject=True, payload=payload)
 
     def definition(self, id):


### PR DESCRIPTION
When calling `TFSAPI.definitions()` without parameter `nameFilter`, a `UnboundLocalError` is raised ("UnboundLocalError: local variable 'payload' referenced before assignment" in line 195 of `connection.py`) This pull request fixes this issue (and as a side effect also updates the docstring to match the parameter name).